### PR TITLE
Fix bug when gathering resources.

### DIFF
--- a/itsyscape/ItsyScape/Game/GatherResourceCommand.lua
+++ b/itsyscape/ItsyScape/Game/GatherResourceCommand.lua
@@ -18,7 +18,7 @@ local PropResourceHealthBehavior = require "ItsyScape.Peep.Behaviors.PropResourc
 local GatherResourceCommand = Class(Command)
 GatherResourceCommand.FINISH_DELAY = 0.5
 
-function GatherResourceCommand:new(prop, tool, t)
+function GatherResourceCommand:new(prop, tool, callback, t)
 	Command.new(self)
 
 	t = t or {}
@@ -29,6 +29,7 @@ function GatherResourceCommand:new(prop, tool, t)
 	self.skin = t.skin or false
 	self.time = 0
 	self.isFinished = false
+	self.callback = callback
 	self._onResourceObtained = function(...)
 		self:onResourceObtained(...)
 	end
@@ -42,6 +43,10 @@ function GatherResourceCommand:onResourceObtained(peep, e)
 	self.isFinished = true
 	self.time = 0
 	self.cooldown = GatherResourceCommand.FINISH_DELAY
+
+	if self.callback then
+		self.callback()
+	end
 end
 
 function GatherResourceCommand:onBegin(peep)

--- a/itsyscape/Resources/Game/Actions/Make.lua
+++ b/itsyscape/Resources/Game/Actions/Make.lua
@@ -8,6 +8,7 @@
 -- file, You can obtain one at http://mozilla.org/MPL/2.0/.
 --------------------------------------------------------------------------------
 local Class = require "ItsyScape.Common.Class"
+local Callback = require "ItsyScape.Common.Callback"
 local CacheRef = require "ItsyScape.Game.CacheRef"
 local GatherResourceCommand = require "ItsyScape.Game.GatherResourceCommand"
 local Utility = require "ItsyScape.Game.Utility"
@@ -92,10 +93,10 @@ function Make:gather(state, player, prop, toolType, skill)
 					return false
 				end
 
-				local gatherCommand = GatherResourceCommand(prop, bestTool, { skill = skill, skin = skin, action = self })
-				local callbackCommand = CallbackCommand(self.make, self, state, player, prop)
+				local callback = Callback.bind(self.make, self, state, player, prop)
+				local gatherCommand = GatherResourceCommand(prop, bestTool, callback, { skill = skill, skin = skin, action = self })
 				local queue = player:getCommandQueue()
-				queue:interrupt(CompositeCommand(nil, walk, face, gatherCommand, callbackCommand))
+				queue:interrupt(CompositeCommand(nil, walk, face, gatherCommand))
 
 				return true
 			else


### PR DESCRIPTION
When interrupting the 'gather resources' action after the prop is depleted, but before the resource is obtained, the player would *not* receive the resource. Now, the resource is obtained correctly upon depleting a prop.